### PR TITLE
[WebAssembly] Fix shared library loading

### DIFF
--- a/arch/wasm32/wasm.js
+++ b/arch/wasm32/wasm.js
@@ -966,7 +966,7 @@ if (arguments[0] == '--dump-ffi-symbols') {
     instance = new WebAssembly.Instance(new WebAssembly.Module(buf), ffi)
     // For the application exports its memory, we use that rather than
     // the one we created. In this way this code works with modules that
-    // import or export thier memory.
+    // import or export their memory.
     if (instance.exports.memory) {
       heap = instance.exports.memory.buffer;
       heap_uint8 = new Uint8Array(heap);

--- a/arch/wasm32/wasm.js
+++ b/arch/wasm32/wasm.js
@@ -973,12 +973,13 @@ if (arguments[0] == '--dump-ffi-symbols') {
   for (var i = arguments.length - 1; i > 0; --i) {
     var path = arguments[i];
     modules[i] = load_wasm(path);
-    for (var f in modules[i]) {
+    for (var f in modules[i].exports) {
       // TODO wasm modules don't have hasOwnProperty. They probably should.
       //      The code should look like:
       //      if (modules[i].hasOwnProperty(f) &&
       //          modules[i][f] instanceof Function)
-      ffi[f] = modules[i][f];
+      if (modules[i].exports[f] instanceof Function)
+        ffi['env'][f] = modules[i].exports[f];
     }
   }
 

--- a/libc.py
+++ b/libc.py
@@ -171,6 +171,7 @@ class AsmCompiler(Compiler):
     return os.path.basename(src)[:-1] + 'll'  # .c -> .ll
 
   def binary(self):
+    max_memory = str(16 * 1024 * 1024)
     bytecode = change_extension(self.out, '.bc')
     assembly = os.path.join(self.tmpdir, self.outbase + '.s')
     check_output([os.path.join(self.clang_dir, 'llvm-link'),
@@ -180,7 +181,8 @@ class AsmCompiler(Compiler):
                   bytecode, '-o', assembly],
                  cwd=self.tmpdir)
     check_output([os.path.join(self.binaryen_dir, 's2wasm'),
-                  assembly, '--ignore-unknown', '-o', self.out],
+                  assembly, '--ignore-unknown', '-o', self.out,
+                  '--import-memory', '-m', max_memory],
                  cwd=self.tmpdir)
 
     if self.sexpr_wasm:


### PR DESCRIPTION
Loading of shared libraries was broken back in:
https://github.com/jfbastien/musl/commit/39fde6042ee22bc75556f4ba063775b3e457e471

This change restores the ability for shared libraries to
be loaded such that they can share memory and provide
function exports to the main executable.

However the executable that libraries still need to built
 in a specific way (i.e. all imported the same sized memory)
and their static globals need to be in the different address
range.    This has the complication that the executables won't
run the wasm spec interpreter (since it doesn't pass in a
memory to the executables it runs).   So although I'm fixing this
here in the musl repo I'm also proposiing that we remove the
continuous testing of this configurations on the wasm waterfall
in favor of concentrating on the statically linking lld case:
https://github.com/WebAssembly/waterfall/pull/271