### PR TITLE
Support node.js in wasm loader

### DIFF
--- a/arch/wasm32/wasm.js
+++ b/arch/wasm32/wasm.js
@@ -34,8 +34,6 @@ if (typeof process === 'object' && typeof require === 'function') { // This is n
   const nodePath = require('path');
   var read = function(file_path) {
     filename = nodePath['normalize'](file_path);
-    console.log(file_path);
-    console.log(filename);
     return nodeFS['readFileSync'](filename);
   }
   var print = console.log;

--- a/arch/wasm32/wasm.js
+++ b/arch/wasm32/wasm.js
@@ -28,6 +28,20 @@ var heap;
 var heap_uint8;
 var heap_uint32;
 
+if (typeof process === 'object' && typeof require === 'function') { // This is node.js
+  // Emulate JS shell behavior used below
+  const nodeFS = require('fs');
+  const nodePath = require('path');
+  var read = function(file_path) {
+    filename = nodePath['normalize'](file_path);
+    console.log(file_path);
+    console.log(filename);
+    return nodeFS['readFileSync'](filename);
+  }
+  var print = console.log;
+  arguments = process['argv'].slice(2);
+}
+
 function setHeap(h) {
   heap = h
   heap_uint8 = new Uint8Array(heap);


### PR DESCRIPTION
The latest LTS of Node supports wasm, and this allows us to test
against it, as well as the shells.