### PR TITLE
[WebAssembly] Add call to __wasm_call_ctors on startup if found

### DIFF
--- a/arch/wasm32/wasm.js
+++ b/arch/wasm32/wasm.js
@@ -1479,6 +1479,8 @@ if (!(modules[i].exports.main instanceof Function))
   throw new Error('main() not found');
 
 try {
+  if (modules[i].exports.__wasm_call_ctors instanceof Function)
+    modules[0].exports.__wasm_call_ctors();
   var ret = modules[0].exports.main();
   stdio.__flush_stdout();
   print(main_module + '::main() returned ' + ret);

--- a/arch/wasm32/wasm.js
+++ b/arch/wasm32/wasm.js
@@ -1475,11 +1475,11 @@ var main_module = arguments[0];
 modules[0] = load_wasm(main_module);
 heap_end = modules[0].exports.__heap_base;
 
-if (!(modules[i].exports.main instanceof Function))
+if (!(modules[0].exports.main instanceof Function))
   throw new Error('main() not found');
 
 try {
-  if (modules[i].exports.__wasm_call_ctors instanceof Function)
+  if (modules[0].exports.__wasm_call_ctors instanceof Function)
     modules[0].exports.__wasm_call_ctors();
   var ret = modules[0].exports.main();
   stdio.__flush_stdout();


### PR DESCRIPTION
This function is constructed by the linker (lld) based on the ctor functions in the inputs.  We could call it from _start, but since we calling main() directly here, we should also call __wasm_call_ctors.