### PR TITLE
[WIP] Simple memory grow implementation

### DIFF
--- a/arch/wasm32/atomic_arch.h
+++ b/arch/wasm32/atomic_arch.h
@@ -4,7 +4,7 @@
 
 #include <stdlib.h>
 
-#define a_barrier() syscall(__NR_membarrier)
+#define a_barrier() (0)
 
 #define a_cas a_cas
 static inline int a_cas(volatile int *p, int t, int s)

--- a/arch/wasm32/pthread_arch.h
+++ b/arch/wasm32/pthread_arch.h
@@ -7,3 +7,8 @@ static inline struct pthread *__pthread_self(void) {
 #define CANCEL_REG_IP 16
 
 #define MC_PC gregs[REG_EIP]
+
+#define __wait __wait
+static inline void __wait(volatile int *addr, volatile int *waiters, int cnt, int priv) {}
+static inline void __wake(volatile void *addr, int cnt, int priv) {}
+static inline void __futexwait(volatile void *addr, int val, int priv) {}

--- a/arch/wasm32/pthread_arch.h
+++ b/arch/wasm32/pthread_arch.h
@@ -12,3 +12,8 @@ static inline struct pthread *__pthread_self(void) {
 static inline void __wait(volatile int *addr, volatile int *waiters, int cnt, int priv) {}
 static inline void __wake(volatile void *addr, int cnt, int priv) {}
 static inline void __futexwait(volatile void *addr, int val, int priv) {}
+
+#define __block_all_sigs __block_all_sigs
+static inline void __block_all_sigs(void *set) {}
+static inline void __block_app_sigs(void *set) {}
+static inline void __restore_sigs(void *set) {}

--- a/src/internal/malloc_impl.h
+++ b/src/internal/malloc_impl.h
@@ -34,7 +34,13 @@ struct bin {
 
 #define C_INUSE  ((size_t)1)
 
+#ifndef __wasm__
 #define IS_MMAPPED(c) !((c)->csize & (C_INUSE))
+#else
+#undef MMAP_THRESHOLD
+#define MMAP_THRESHOLD ((size_t)-1)
+#define IS_MMAPPED(c) (0)
+#endif
 
 __attribute__((__visibility__("hidden")))
 void __bin_chunk(struct chunk *);

--- a/src/internal/pthread_impl.h
+++ b/src/internal/pthread_impl.h
@@ -150,6 +150,8 @@ void __vm_unlock(void);
 
 int __timedwait(volatile int *, int, clockid_t, const struct timespec *, int);
 int __timedwait_cp(volatile int *, int, clockid_t, const struct timespec *, int);
+
+#ifndef __wait
 void __wait(volatile int *, volatile int *, int, int);
 static inline void __wake(volatile void *addr, int cnt, int priv)
 {
@@ -164,6 +166,7 @@ static inline void __futexwait(volatile void *addr, int val, int priv)
 	__syscall(SYS_futex, addr, FUTEX_WAIT|priv, val) != -ENOSYS ||
 	__syscall(SYS_futex, addr, FUTEX_WAIT, val);
 }
+#endif
 
 void __acquire_ptc(void);
 void __release_ptc(void);

--- a/src/internal/pthread_impl.h
+++ b/src/internal/pthread_impl.h
@@ -172,9 +172,11 @@ void __acquire_ptc(void);
 void __release_ptc(void);
 void __inhibit_ptc(void);
 
+#ifndef __block_all_sigs
 void __block_all_sigs(void *);
 void __block_app_sigs(void *);
 void __restore_sigs(void *);
+#endif
 
 #define DEFAULT_STACK_SIZE 81920
 #define DEFAULT_GUARD_SIZE 4096

--- a/src/malloc/malloc.c
+++ b/src/malloc/malloc.c
@@ -99,6 +99,7 @@ static int bin_index_up(size_t x)
 	if (x <= 32) return x;
 	x--;
 	if (x < 512) return bin_tab[x/8-4] + 1;
+	if (x > 0x1c00) return 63;
 	return bin_tab[x/128-4] + 17;
 }
 

--- a/src/malloc/wasm32/expand_heap.c
+++ b/src/malloc/wasm32/expand_heap.c
@@ -1,0 +1,28 @@
+#include <limits.h>
+#include <stdint.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include "libc.h"
+#include "syscall.h"
+
+#define WASM_PAGE_SIZE 65536
+
+/* Expand the heap in-place use WebAssembly grow_memory operators.
+ * The caller is responsible for locking to prevent concurrent calls. */
+
+void *__expand_heap(size_t *pn)
+{
+	size_t n = *pn;
+	n += -n & WASM_PAGE_SIZE-1;
+	unsigned delta = n / WASM_PAGE_SIZE;
+
+	unsigned res = __builtin_wasm_memory_grow(0, delta);
+	if (res == (unsigned)-1) {
+		errno = ENOMEM;
+		return 0;
+	}
+
+	void *area = (void*)(WASM_PAGE_SIZE * res);
+	*pn = n;
+	return area;
+}

--- a/src/mman/wasm32/madvise.c
+++ b/src/mman/wasm32/madvise.c
@@ -1,0 +1,6 @@
+#include <sys/mman.h>
+#include "libc.h"
+
+int __madvise(void *addr, size_t len, int advice) { return 0; }
+
+weak_alias(__madvise, madvise);

--- a/src/signal/wasm32/block.c
+++ b/src/signal/wasm32/block.c
@@ -1,0 +1,1 @@
+#include "pthread_impl.h"

--- a/src/signal/wasm32/raise.c
+++ b/src/signal/wasm32/raise.c
@@ -1,0 +1,3 @@
+#include <signal.h>
+
+int raise(int sig) { }

--- a/src/thread/wasm32/__wait.c
+++ b/src/thread/wasm32/__wait.c
@@ -1,0 +1,2 @@
+#include "pthread_impl.h"
+


### PR DESCRIPTION
It is natural for wasm. That (and included __wait/__wake stubs) removes syscall imports for simple C code.