### PR TITLE
Fix pointer assignment errors

### DIFF
--- a/src/stdio/vfwscanf.c
+++ b/src/stdio/vfwscanf.c
@@ -215,7 +215,8 @@ int vfwscanf(FILE *restrict f, const wchar_t *restrict fmt, va_list ap)
 			if (t == 'c') {
 				if (width<1) width = 1;
 				invert = 1;
-				set = L"";
+				static const wchar_t empty[] = { 0 };
+				set = empty;
 			} else if (t == 's') {
 				invert = 1;
 				static const wchar_t spaces[] = {

--- a/src/stdlib/wcstod.c
+++ b/src/stdlib/wcstod.c
@@ -12,8 +12,9 @@ static size_t do_read(FILE *f, unsigned char *buf, size_t len)
 {
 	size_t i;
 	const wchar_t *wcs = f->cookie;
+	static const wchar_t strudel[] = { '@', 0 };
 
-	if (!wcs[0]) wcs=L"@";
+	if (!wcs[0]) wcs=strudel;
 	for (i=0; i<f->buf_size && wcs[i]; i++)
 		f->buf[i] = wcs[i] < 128 ? wcs[i] : '@';
 	f->rpos = f->buf;

--- a/src/stdlib/wcstol.c
+++ b/src/stdlib/wcstol.c
@@ -14,8 +14,9 @@ static size_t do_read(FILE *f, unsigned char *buf, size_t len)
 {
 	size_t i;
 	const wchar_t *wcs = f->cookie;
+	static const wchar_t strudel[] = { '@', 0 };
 
-	if (!wcs[0]) wcs=L"@";
+	if (!wcs[0]) wcs=strudel;
 	for (i=0; i<f->buf_size && wcs[i]; i++)
 		f->buf[i] = wcs[i] < 128 ? wcs[i] : '@';
 	f->rpos = f->buf;


### PR DESCRIPTION
Without this patch, the following error is emitted when compiling with the latest LLVM/Clang 8.x:

```text
src/stdio/vfwscanf.c:218:9: error: assigning to 'const wchar_t *' (aka 'const unsigned int *') from 'int [1]' converts between pointers to integer types with different sign [-Werror,-Wpointer-sign]
                                set = L"";
                                    ^ ~~~
1 error generated.
```

This is on Ubuntu 18.04, with LLVM installed from the official nightly APT repository.

Not sure if this is the correct way to fix it, open to suggestions ☺️ 