### PR TITLE
Update types to match the reference-sysroot types.

### DIFF
--- a/arch/wasm32/bits/alltypes.h.in
+++ b/arch/wasm32/bits/alltypes.h.in
@@ -1,21 +1,22 @@
-#define _Addr long
-#define _Int64 long long
-#define _Reg int
+#define _Addr __PTRDIFF_TYPE__
+#define _Int64 __INT64_TYPE__
+#define _Reg __INT64_TYPE__
 
 TYPEDEF __builtin_va_list va_list;
 TYPEDEF __builtin_va_list __isoc_va_list;
 
 #ifndef __cplusplus
-TYPEDEF unsigned wchar_t;
+TYPEDEF int wchar_t;
 #endif
+TYPEDEF int wint_t;
 
 TYPEDEF float float_t;
 TYPEDEF double double_t;
 
 TYPEDEF struct { long long __ll; long double __ld; } max_align_t;
 
-TYPEDEF long time_t;
-TYPEDEF long suseconds_t;
+TYPEDEF long long time_t;
+TYPEDEF long long suseconds_t;
 
 TYPEDEF struct { union { int __i[9]; volatile int __vi[9]; unsigned __s[9]; } __u; } pthread_attr_t;
 TYPEDEF struct { union { int __i[6]; volatile int __vi[6]; volatile void *volatile __p[6]; } __u; } pthread_mutex_t;

--- a/arch/wasm32/bits/stat.h
+++ b/arch/wasm32/bits/stat.h
@@ -1,22 +1,22 @@
 /* copied from kernel definition, but with padding replaced
  * by the corresponding correctly-sized userspace types. */
 
-struct stat
-{
+struct stat {
 	dev_t st_dev;
-	int __st_dev_padding;
-	long __st_ino_truncated;
-	mode_t st_mode;
+	ino_t st_ino;
 	nlink_t st_nlink;
+
+	mode_t st_mode;
 	uid_t st_uid;
 	gid_t st_gid;
+	unsigned int    __pad0;
 	dev_t st_rdev;
-	int __st_rdev_padding;
 	off_t st_size;
 	blksize_t st_blksize;
 	blkcnt_t st_blocks;
+
 	struct timespec st_atim;
 	struct timespec st_mtim;
 	struct timespec st_ctim;
-	ino_t st_ino;
+	long long __unused[3];
 };


### PR DESCRIPTION
Notably, this includes a fix for the 2038 bug, and large-file support. See also the corresponding changes to other libc sources:

https://github.com/WebAssembly/reference-sysroot/pull/8
https://github.com/kripken/emscripten/pull/7799
